### PR TITLE
Re-add Betty Dexter to list.

### DIFF
--- a/spec/intro.tex
+++ b/spec/intro.tex
@@ -145,7 +145,7 @@ Wise, J\"org F. Wittenberger, Kevin A. Wortman, Sascha Ziemann.
 In addition we would like to thank all the past editors, and the
 people who helped them in turn: Hal Abelson, Norman Adams, David
 Bartley, Alan Bawden, Michael Blair, Gary Brooks, George Carrette,
-Andy Cromarty, Pavel Curtis, Jeff Dalton, Olivier Danvy, Ken Dickey,
+Andy Cromarty, Pavel Curtis, Jeff Dalton, Olivier Danvy, Betty Dexter, Ken Dickey,
 Bruce Duba, Robert Findler, Andy Freeman, Richard Gabriel, Yekta
 G\"ursel, Ken Haase, Robert Halstead, Robert Hieb, Paul Hudak, Morry
 Katz, Eugene Kohlbecker, Chris Lindblad, Jacob Matthews, Mark Meyer,


### PR DESCRIPTION
She had originally set it in TeX, and the line about this was commented out, but she wasn't added to the past people who helped.